### PR TITLE
use multiple consumers to speed up report generation

### DIFF
--- a/src/main/java/uk/gov/ons/fsdr/report/entity/Report.java
+++ b/src/main/java/uk/gov/ons/fsdr/report/entity/Report.java
@@ -9,6 +9,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Version;
 
 @Entity
 @Table(name = "report")
@@ -145,6 +146,10 @@ public class Report {
 
   @Column(name = "lws_complete")
   private String lwsComplete;
+
+  @Version
+  @Column(name = "VERSION", columnDefinition = "integer DEFAULT 0", nullable = false)
+  private long version;
 
   public Report(String uniqueEmployeeId) {
     this.uniqueEmployeeId = uniqueEmployeeId;

--- a/src/main/java/uk/gov/ons/fsdr/report/service/CsvService.java
+++ b/src/main/java/uk/gov/ons/fsdr/report/service/CsvService.java
@@ -94,7 +94,7 @@ public class CsvService {
     header[2] = "job title";
     header[3] = "ingest time";
     header[4] = "adecco ingest start time";
-    header[5] = "adecco ingest start time";
+    header[5] = "adecco ingest complete time";
     header[6] = "adecco create employee start time";
     header[7] = "adecco create employee end time";
     header[8] = "nisra ingest csv start time";

--- a/src/main/java/uk/gov/ons/fsdr/report/service/ReportService.java
+++ b/src/main/java/uk/gov/ons/fsdr/report/service/ReportService.java
@@ -33,7 +33,7 @@ public class ReportService {
   }
 
   @RabbitHandler
-  public void readMessage(GatewayEventDTO event) {
+  public void readMessage(GatewayEventDTO event) throws InterruptedException {
 
     String caseId = event.getCaseId();
     log.debug("processing event: {} for ID: {}", event.getEventType(), caseId);
@@ -41,7 +41,7 @@ public class ReportService {
     updateReport(report, event);
   }
 
-  private void updateReport(Report report, GatewayEventDTO gatewayEventDTO) {
+  private void updateReport(Report report, GatewayEventDTO gatewayEventDTO) throws InterruptedException {
     String eventTime = gatewayEventDTO.getMetadata().get("TS");
     switch (gatewayEventDTO.getEventType()) {
     case "JOB_TYPE":
@@ -178,6 +178,7 @@ public class ReportService {
       report.setActionType(ActionType.LEAVER);
       break;
     case "FSDR_PROCESS_COMPLETE":
+      Thread.sleep(30000);
       eventManager.triggerEvent("<N/A>", FSDR_REPORT_READY);
     default:
       return;

--- a/src/main/java/uk/gov/ons/fsdr/report/service/ReportService.java
+++ b/src/main/java/uk/gov/ons/fsdr/report/service/ReportService.java
@@ -41,7 +41,7 @@ public class ReportService {
   }
 
   @RabbitHandler
-  public void readMessage(GatewayEventDTO event) throws InterruptedException {
+  public void readMessage(GatewayEventDTO event) {
 
     String caseId = event.getCaseId();
     log.debug("processing event: {} for ID: {}", event.getEventType(), caseId);
@@ -49,7 +49,7 @@ public class ReportService {
     updateReport(report, event);
   }
 
-  private void updateReport(Report report, GatewayEventDTO gatewayEventDTO) throws InterruptedException {
+  private void updateReport(Report report, GatewayEventDTO gatewayEventDTO) {
     String eventTime = gatewayEventDTO.getMetadata().get("TS");
     switch (gatewayEventDTO.getEventType()) {
     case "JOB_TYPE":

--- a/src/main/java/uk/gov/ons/fsdr/report/service/ReportService.java
+++ b/src/main/java/uk/gov/ons/fsdr/report/service/ReportService.java
@@ -55,6 +55,9 @@ public class ReportService {
     case "JOB_TYPE":
       report.setJobTitle(gatewayEventDTO.getMetadata().get("JobRole Type"));
       break;
+    case "FSDR_PROCESS_STARTED":
+      report.setStartTime(eventTime);
+      break;
     case "GSUITE_ACTION_STARTED":
       report.setGsuiteActionStart(eventTime);
       break;
@@ -106,7 +109,6 @@ public class ReportService {
       break;
     case "ADECCO_INGEST_STARTED":
       report.setAdeccoIngestStart(eventTime);
-      report.setStartTime(eventTime);
       break;
     case "ADECCO_INGEST_COMPLETE":
       report.setAdeccoIngestComplete(eventTime);
@@ -156,7 +158,6 @@ public class ReportService {
       break;
     case "NISRA_INGEST_STARTED":
       report.setNisraIngestCsvStart(eventTime);
-      report.setStartTime(eventTime);
       break;
     case "NISRA_INGEST_COMPLETE":
       report.setNisraIngestCsvComplete(eventTime);
@@ -189,8 +190,7 @@ public class ReportService {
       boolean retryResult = checkEventQueue(timeToWait);
       if (retryResult) {
         eventManager.triggerEvent("<N/A>", FSDR_REPORT_READY);
-      }
-      else {
+      } else {
         log.error("event queue did not finish processing in {}ms, report may need to be generated manually",
             timeToWait);
       }
@@ -212,7 +212,7 @@ public class ReportService {
     while (keepChecking) {
       boolean result = checkIfQueueEmpty();
 
-      if (result){
+      if (result) {
         return true;
       }
 

--- a/src/main/java/uk/gov/ons/fsdr/report/service/ReportService.java
+++ b/src/main/java/uk/gov/ons/fsdr/report/service/ReportService.java
@@ -45,7 +45,8 @@ public class ReportService {
 
     String caseId = event.getCaseId();
     log.debug("processing event: {} for ID: {}", event.getEventType(), caseId);
-    Report report = reportRepository.findById(caseId).orElse(new Report(caseId));
+    Report report = reportRepository.findById(caseId)
+        .orElseGet(() -> reportRepository.saveAndFlush(new Report(caseId)));
     updateReport(report, event);
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,9 +18,16 @@ spring:
     username: guest
     password: guest
     virtual-host: /
+    listener:
+      simple:
+        concurrency: 10
+  jpa:
+    hibernate:
+      ddl-auto: update
 logging:
   level:
     uk.gov.ons.fsdr.report: DEBUG
     org.springframework.amqp: WARN
     org.hibernate: WARN
+    org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler: ERROR
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,5 @@ logging:
     org.hibernate: WARN
     org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler: ERROR
 
+report:
+  timeout: 120000


### PR DESCRIPTION
- add multiple rabbit consumers configurable using application.yml 

- add `@Version` to report entity so that if multiple consumers try to update the same entity an exception will be thrown and the message requeued

- use AmqpAdmin to check if report queue is empty before sending report ready event